### PR TITLE
Added link to supported docs on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             <li><a href="/devdocs-archive/2.0/">Magento 2.0 (2.0.18)</a></li>
             <li><a href="/devdocs-archive/1.x/">Magento 1 (1.9/1.14)</a></li>
          </ul>
-        <p>See <a href="https://developer.adobe.com/commerce/docs/">https://developer.adobe.com/commerce/docs/</a> for the latest supported developer documentation.</p>
+        <p>See actively maintained <a href="https://developer.adobe.com/commerce/docs/">developer documentation</a> for the latest supported releases.</p>
       </main>
       <!-- <footer></footer> -->
    </body>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       <main class="container">
         <h1>Commerce Developer Documentation Archive</h1>
          <p>This site contains archived developer documentation for versions of Adobe Commerce and Magento Open Source that have reached <a href="https://experienceleague.adobe.com/docs/commerce-operations/release/versions.html">end-of-support</a>.</p>
-         <p>The documentation available here is intended for historical reference only and is not maintained.</p>
+         <p>The documentation available here is intended for historical reference only and is not maintained. See <a href="https://developer.adobe.com/commerce/docs/">https://developer.adobe.com/commerce/docs/</a> for the latest supported developer documentation.</p>
          <ul>
             <li><a href="/devdocs-archive/2.3/">Magento 2.3 (2.3.7)</a></li>
             <li><a href="/devdocs-archive/2.2/">Magento 2.2 (2.2.11)</a></li>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       <main class="container">
         <h1>Commerce Developer Documentation Archive</h1>
          <p>This site contains archived developer documentation for versions of Adobe Commerce and Magento Open Source that have reached <a href="https://experienceleague.adobe.com/docs/commerce-operations/release/versions.html">end-of-support</a>.</p>
-         <p>The documentation available here is intended for historical reference only and is not maintained. See <a href="https://developer.adobe.com/commerce/docs/">https://developer.adobe.com/commerce/docs/</a> for the latest supported developer documentation.</p>
+         <p>The documentation available here is intended for historical reference only and is not maintained.</p>
          <ul>
             <li><a href="/devdocs-archive/2.3/">Magento 2.3 (2.3.7)</a></li>
             <li><a href="/devdocs-archive/2.2/">Magento 2.2 (2.2.11)</a></li>
@@ -28,6 +28,7 @@
             <li><a href="/devdocs-archive/2.0/">Magento 2.0 (2.0.18)</a></li>
             <li><a href="/devdocs-archive/1.x/">Magento 1 (1.9/1.14)</a></li>
          </ul>
+        <p>See <a href="https://developer.adobe.com/commerce/docs/">https://developer.adobe.com/commerce/docs/</a> for the latest supported developer documentation.</p>
       </main>
       <!-- <footer></footer> -->
    </body>

--- a/index.html
+++ b/index.html
@@ -22,11 +22,11 @@
          <p>This site contains archived developer documentation for versions of Adobe Commerce and Magento Open Source that have reached <a href="https://experienceleague.adobe.com/docs/commerce-operations/release/versions.html">end-of-support</a>.</p>
          <p>The documentation available here is intended for historical reference only and is not maintained.</p>
          <ul>
-            <li><a href="/devdocs-archive/2.3/">Magento 2.3 (2.3.7)</a></li>
-            <li><a href="/devdocs-archive/2.2/">Magento 2.2 (2.2.11)</a></li>
-            <li><a href="/devdocs-archive/2.1/">Magento 2.1 (2.1.18)</a></li>
-            <li><a href="/devdocs-archive/2.0/">Magento 2.0 (2.0.18)</a></li>
-            <li><a href="/devdocs-archive/1.x/">Magento 1 (1.9/1.14)</a></li>
+            <li><a href="/devdocs-archive/2.3/">2.3 (2.3.7)</a></li>
+            <li><a href="/devdocs-archive/2.2/">2.2 (2.2.11)</a></li>
+            <li><a href="/devdocs-archive/2.1/">2.1 (2.1.18)</a></li>
+            <li><a href="/devdocs-archive/2.0/">2.0 (2.0.18)</a></li>
+            <li><a href="/devdocs-archive/1.x/">1.x (1.9/1.14)</a></li>
          </ul>
         <p>See actively maintained <a href="https://developer.adobe.com/commerce/docs/">developer documentation</a> for the latest supported releases.</p>
       </main>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a link to supported docs on the landing page as a follow up to #1.

## Affected DevDocs pages

-  https://commerce-docs.github.io/devdocs-archive/